### PR TITLE
Fix menu.css - rake aborted when recompile asset (production)

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -19,7 +19,7 @@ require 'capistrano/rvm'
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
  require 'capistrano/bundler'
-# require 'capistrano/rails/assets'
+ require 'capistrano/rails/assets'
  require 'capistrano/rails/migrations'
 # require 'capistrano/passenger'
 

--- a/app/assets/stylesheets/menu.css
+++ b/app/assets/stylesheets/menu.css
@@ -16,9 +16,9 @@
 	/*background: #fff;*/
 	/*
 	box-shadow: 0 6px #34495e, 0 12px #fff, 0 18px #34495e, 0 24px #fff;
-		content: '';*/
+		content: '';
 	
-}
+}*/
 
 .mp-pusher {
 	position: relative;


### PR DESCRIPTION
Fix this error -
rake aborted!
Sass::SyntaxError: Invalid CSS after "          content: '';*/": expected selector or at-rule, was "}"
  (in /home/shimah/rails/training_cloud/etain/app/assets/stylesheets/application.css)
(sass):8009


